### PR TITLE
make the main run function be exported for use elsewhere

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const reader = require('../lib/reader');
+const searcher = require('../lib/searcher');
+const reporter = require('../lib/reporter');
+const log = require('../lib/log-color');
+
+module.exports = function run (directory) {
+  let packageJson;
+  try {
+    packageJson = reader.read(directory + '/package.json');
+  } catch (e) {
+    log.red('package.json is require');
+    process.exit(1);
+  }
+  const dependencies = searcher.searchDependencies(packageJson);
+  const files = reader.find(directory);
+  const result = [];
+  files.forEach(file => {
+    const lines = reader.read(file);
+    const declarations = searcher.searchDeclarations(lines, dependencies);
+    const usage = searcher.searchUsage(lines, file, declarations);
+    if (usage.length) {
+      result.push(usage);
+    }
+  });
+  reporter.report(result, dependencies);
+  reporter.fileReport(result, dependencies);
+};

--- a/bin/szero.js
+++ b/bin/szero.js
@@ -1,34 +1,7 @@
 #! /usr/bin/env node
 
-'use strict';
-
-const reader = require('../lib/reader');
-const searcher = require('../lib/searcher');
-const reporter = require('../lib/reporter');
+const run = require('./cli');
 const log = require('../lib/log-color');
-
-function run (directory) {
-  let packageJson;
-  try {
-    packageJson = reader.read(directory + '/package.json');
-  } catch (e) {
-    log.red('package.json is require');
-    process.exit(1);
-  }
-  const dependencies = searcher.searchDependencies(packageJson);
-  const files = reader.find(directory);
-  const result = [];
-  files.forEach(file => {
-    const lines = reader.read(file);
-    const declarations = searcher.searchDeclarations(lines, dependencies);
-    const usage = searcher.searchUsage(lines, file, declarations);
-    if (usage.length) {
-      result.push(usage);
-    }
-  });
-  reporter.report(result, dependencies);
-  reporter.fileReport(result, dependencies);
-}
 
 if (process.argv.length === 3) {
   run(process.argv[2]);


### PR DESCRIPTION
@helio-frota i've extracted that "run" function into its own thing, so both the `bin/szero` and the upcoming changes for #16 can use it

will merge once tests come back ok, which should be ok