### PR TITLE
replace the hard-coded list of core modules with the repl._builtinLibs

### DIFF
--- a/lib/searcher.js
+++ b/lib/searcher.js
@@ -76,10 +76,7 @@ function searchDeclarations (lines, dependencies) {
 
 function searchMissingDependencies (lines, dependencies) {
   const missingDeps = [];
-  const coreModules = [ 'assert', 'buffer', 'child_process', 'cluster',
-    'crypto', 'dgram', 'dns', 'domain', 'events', 'fs', 'http', 'https',
-    'net', 'os', 'path', 'punycode', 'querystring', 'readline', 'stream',
-    'string_decoder', 'tls', 'tty', 'url', 'util', 'v8', 'vm', 'zlib' ];
+  const coreModules = require('repl')._builtinLibs;
   dependencies.push(coreModules);
   lines.forEach(l => {
     if (l.includes('require(')) {


### PR DESCRIPTION
for #36 