### PR TITLE
ensure inline requires are searched local dependencies are ignored

### DIFF
--- a/lib/searcher.js
+++ b/lib/searcher.js
@@ -42,28 +42,14 @@ function searchDependencies (lines, includeDev) {
   return allDeps;
 }
 
-function extractRequire (line) {
-  let req = line.split('=')[1].trim();
-  req = req.substring(0, req.lastIndexOf(';'));
-  return req.trim();
-}
-
-function extractVarName (line) {
-  let name = line.split('=')[0];
-  name = name.replace('var', '');
-  name = name.replace('let', '');
-  name = name.replace('const', '');
-  return name.trim();
-}
-
 function searchDeclarations (lines, dependencies) {
   const declarations = [];
   dependencies.forEach(d => {
     lines.forEach(l => {
       if (l.includes(d)) {
-        if (l.includes('=')) {
-          let extractedRequire = extractRequire(l);
-          let extractedVarName = extractVarName(l);
+        let extractedRequire = getRequireFromLine(l);
+        if (extractedRequire) {
+          let extractedVarName = getTextFromRequire(l);
           if (extractedRequire && extractedVarName) {
             declarations.push(extractedVarName + '-' + extractedRequire);
           }
@@ -74,20 +60,40 @@ function searchDeclarations (lines, dependencies) {
   return declarations;
 }
 
+/**
+ * Plucks a require statment from a given line of code, e.g passing the line
+ * "app.use(require('lib/routes'))" would return "require('lib/routes')"
+ * @param  {String} l
+ * @return {String|null}
+ */
+function getRequireFromLine (l) {
+  var req = l.match(/require(.*?)\)/g);
+
+  return req ? req[0] : null;
+}
+
+/**
+ * Plucks the specific require string from a require statment, e.g given
+ * "require('lib/routes')" this would return "lib/routes"
+ * @param  {String} req
+ * @return {String}
+ */
+function getTextFromRequire (req) {
+  return req.match(/["'](.*?)["']/)[1];
+}
+
 function searchMissingDependencies (lines, dependencies) {
   const missingDeps = [];
   const coreModules = require('repl')._builtinLibs;
   dependencies.push(coreModules);
   lines.forEach(l => {
     if (l.includes('require(')) {
-      let missing = l.split('=')[1];
-      if (!missing.includes('./')) {
-        missing = missing.replace('require(', '');
-        missing = missing.replace(')', '');
-        missing = missing.replace(/"/g, '');
-        missing = missing.replace(/'/g, '');
-        missing = missing.replace(';', '');
-        missing = missing.trim();
+      let missing = getRequireFromLine(l);
+
+      // Only search if not a local dependency
+      if (missing && !missing.includes('/')) {
+        missing = getTextFromRequire(missing).trim();
+
         let deps = dependencies[0].find(d => {
           return d === missing;
         });

--- a/test/fixtures/foo/x.js
+++ b/test/fixtures/foo/x.js
@@ -5,3 +5,4 @@ const roi = require('roi');
 
 console.log(fs);
 console.log(roi);
+console.log(require('ramda'));

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -9,7 +9,8 @@
   "dependencies": {
     "roi": "^0.2.'",
     "fidelity": "0.1.2",
-    "request": "1.2.3"
+    "request": "1.2.3",
+    "ramda": "*"
   },
   "license": "Apache-2.0",
   "devDependencies": {

--- a/test/szero-cli-test.js
+++ b/test/szero-cli-test.js
@@ -23,3 +23,15 @@ test('Should pass and return an object with real project', (t) => {
     t.end();
   });
 });
+
+test('Should run a summary report', (t) => {
+  cli(path.join(__dirname, '/fixtures'), {
+    summary: true
+  }).then((report) => {
+    t.deepEqual(report.dependencies, [ 'roi', 'fidelity', 'request', 'ramda' ]);
+    t.deepEqual(report.unused, [ 'request' ]);
+    t.deepEqual(report.devDependencies, []);
+    t.pass();
+    t.end();
+  });
+});


### PR DESCRIPTION
Great module, and something I found the need for just the other day during a PR review! I've found a small bug and patched it. Here's an overview:

My project had a file with these lines:

```js
asyncThings()
  .then(require('a-module'))
``` 

The above caused an issue in the searcher logic since it relied on a require being assigned a variable (checking for an "=" symbol). It now no longer expects a require to be assigned.

Another minor issue I found was the `missing.includes('./')` piece in `searcher.js`. When using `NODE_PATH=.` we can perform local requires like so `require('lib/a/b.js')` without the need for a leading `./`. This PR should address this also.

I will try add some tests for the `searchDependencies` function that might catch these cases to prevent regression.