### PR TITLE
Using complete path instead relative

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,7 +33,7 @@ module.exports = function run (directory, options) {
       const require = searcher.searchRequires(lines);
       if (require.length) {
         require.forEach(r => {
-          requires.add(r);
+          requires.add(file);
         });
       }
 


### PR DESCRIPTION
#70 -[ Problem with same require but different usage](https://github.com/bucharest-gold/szero/issues/70)

Using the complete path and using Set we will get only one reference by require. This is changing the output and I don't know if it's a problem, but it's solving the bug. Follow the outputs

Before - Wrong length === 9
                 
    require('../b/index.js'),require('../../index.js'),require('../index'),require('../../index'),
    require('../index.js'),require('./a/index.js'),require('./b/index.js'),require('./c/index.js'),require('./c/d/index.js')

Now - Right length === 6

    ./a/index.js,./b/e/index.js,./b/index.js,./c/d/index.js,./c/index.js,./index.js
