### PR TITLE
Duplicated require

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,7 +33,7 @@ module.exports = function run (directory, options) {
       const require = searcher.searchRequires(lines);
       if (require.length) {
         require.forEach(r => {
-          requires.add(r);
+          requires.add(file);
         });
       }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -38,6 +38,8 @@ module.exports = function run (directory, options) {
             m = r.split('"')[1];
           } else if (r.includes("'")) {
             m = r.split("'")[1];
+          } else {
+            return;
           }
           m = m.trim();
           let dirFile = path.dirname(file);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,8 +33,10 @@ module.exports = function run (directory, options) {
       const require = searcher.searchRequires(lines);
       if (require.length) {
         require.forEach(r => {
-          let m = r.replace("require('",'').replace("')",'').replace('.js','')
-          requires.add(path.resolve(file,m));
+          let m = r.replace("require('",'').replace("')",'').replace('.js','').trim()
+          let dirFile = path.dirname(file);
+          let completePath = path.resolve(dirFile, m);
+          requires.add(completePath);
         });
       }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const path = require('path');
 const reader = require('../lib/reader');
 const searcher = require('../lib/searcher');
 const reporter = require('../lib/reporter');
@@ -33,7 +33,8 @@ module.exports = function run (directory, options) {
       const require = searcher.searchRequires(lines);
       if (require.length) {
         require.forEach(r => {
-          requires.add(file);
+          let m = r.replace("require('",'').replace("')",'').replace('.js','')
+          requires.add(path.resolve(file,m));
         });
       }
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -33,10 +33,16 @@ module.exports = function run (directory, options) {
       const require = searcher.searchRequires(lines);
       if (require.length) {
         require.forEach(r => {
-          let m = r.replace("require('",'').replace("')",'').replace('.js','').trim()
+          let m = null;
+          if (r.includes('"')) {
+            m = r.split('"')[1];
+          } else if (r.includes("'")) {
+            m = r.split("'")[1];
+          }
+          m = m.trim();
           let dirFile = path.dirname(file);
           let completePath = path.resolve(dirFile, m);
-          requires.add(completePath);
+          requires.add(path.relative(process.cwd(), completePath));
         });
       }
 

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -177,7 +177,10 @@ function consoleReport (jsonReport, options) {
 
   if (jsonReport.requires) {
     header('[ Requires ]');
-    log.yellow(Array.from(jsonReport.requires));
+    Array.from(jsonReport.requires).sort().forEach((e, i, a) => {
+      log.yellow(`${e}`);  
+    })
+    
     log.yellow(`Require count --> ${jsonReport.requires.size}`);
   }
 }

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -178,9 +178,9 @@ function consoleReport (jsonReport, options) {
   if (jsonReport.requires) {
     header('[ Requires ]');
     Array.from(jsonReport.requires).sort().forEach((e, i, a) => {
-      log.yellow(`${e}`);  
-    })
-    
+      log.yellow(`${e}`);
+    });
+
     log.yellow(`Require count --> ${jsonReport.requires.size}`);
   }
 }


### PR DESCRIPTION
The bug is #70 exists because is a little difficult to detect when there is two modules from different path looking for the same module due to the requires are different:

    require('../../index.js')
    require('../index')

Using complete path of requires is possible to detect when a module is being loaded twice easier, because resolving the path of the module we can have two modules importing the same, but the path will be the same. Combining that with a Set we can ensure we will only get only one reference by module

testing that with foo-szero (A project made from @helio-frota  to see the bug #70 ) my output was:

    /home/tiagofabre/Projetos/foo-szero/a/index
    /home/tiagofabre/Projetos/foo-szero/b/index
    /home/tiagofabre/Projetos/foo-szero/c/d/index
    /home/tiagofabre/Projetos/foo-szero/c/index
    /home/tiagofabre/Projetos/foo-szero/fidelity
    /home/tiagofabre/Projetos/foo-szero/index
    /home/tiagofabre/Projetos/foo-szero/roi
    Require count --> 7


The output isn't as before `require('../index.js')` because when we are counting modules and there is a duplication which module should we show? I consider the best solution is just to show the path of the module just like is in my output.