### PR TITLE
feat: use node-builtins module to get core module list

### DIFF
--- a/lib/searcher.js
+++ b/lib/searcher.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const Dep = require('./dep');
+const coreModules = require('node-builtins');
 
 module.exports = {
   searchDependencies: searchDependencies,
@@ -109,7 +110,6 @@ function getTextFromRequire (req) {
 
 function searchMissingDependencies (lines, dependencies) {
   const missingDeps = [];
-  const coreModules = require('repl')._builtinLibs;
   dependencies.push(coreModules);
   lines.forEach(l => {
     if (l.includes('require(')) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "dependencies": {
     "commander": "^2.9.0",
+    "node-builtins": "^0.1.1",
     "roi": "^0.14.0"
   },
   "license": "Apache-2.0",


### PR DESCRIPTION
This replaces the line of code that gets the core modules list with the `node-builtins` module that i just published, that essesntially just does the same thing.

@helio-frota it's up to you if we want to use it,  