### PR TITLE
Szero #99

### DIFF
--- a/bin/szero.js
+++ b/bin/szero.js
@@ -46,7 +46,7 @@ options.dev = program.dev;
 options.license = program.license;
 
 if (program.summary) {
-  options.dev = true;
+  options.dev = false;
   options.summary = true;
 }
 


### PR DESCRIPTION
Fixed the summary option. When it used, the same shows the
"devDependencies" in the "Unused Dependencies" section.