### PR TITLE
enhance: make package.json read simpler

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,4 +1,5 @@
 'use strict';
+const fs = require('fs');
 const reader = require('../lib/reader');
 const searcher = require('../lib/searcher');
 const reporter = require('../lib/reporter');
@@ -11,11 +12,11 @@ module.exports = function run (directory, options) {
     options = options || {};
 
     try {
-      packageJson = reader.getFileLines(`${directory}/package.json`);
+      const pkg = JSON.parse(fs.readFileSync(`${directory}/package.json`));
+      packageJson = Object.keys(pkg.dependencies);
     } catch (e) {
-      const error = 'package.json is require';
-      log.red(error);
-      return reject(error);
+      packageJson = [];
+      log.red('No package.json file found. Scanning directory for .js files.');
     }
 
     const files = searcher.searchJsFiles(directory, [], options.ignore);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -12,13 +12,11 @@ module.exports = function run (directory, options) {
     options = options || {};
 
     try {
-      const pkg = JSON.parse(fs.readFileSync(`${directory}/package.json`));
-      packageJson = Object.keys(pkg.dependencies);
+      packageJson = JSON.parse(fs.readFileSync(`${directory}/package.json`, 'utf-8'));
     } catch (e) {
       packageJson = [];
       log.red('No package.json file found. Scanning directory for .js files.');
     }
-
     const files = searcher.searchJsFiles(directory, [], options.ignore);
     const dependencies = builder.buildDependencies(packageJson, options);
     const result = builder.buildResult(files, dependencies);

--- a/lib/reporter.js
+++ b/lib/reporter.js
@@ -77,7 +77,7 @@ function unused (declarations, dependencies) {
   return diff.length ? diff : 'None.';
 }
 
-function jsonReporter (result, dependencies, requires) {
+function jsonReport (result, dependencies, requires) {
   const resultFlattened = result.reduce((a, b) => { return a.concat(b); }, []);
   const declarations = resultFlattened.map((m) => { return m.declaration; });
   const grouped = groupedResult(resultFlattened, declarations);
@@ -222,7 +222,7 @@ function summary (jsonReport, missing) {
 }
 
 module.exports = {
-  jsonReport: jsonReporter,
+  jsonReport,
   licenseReport: licenseReporter,
   consoleReport,
   createFileReport,

--- a/lib/searcher.js
+++ b/lib/searcher.js
@@ -4,28 +4,8 @@ const Dependency = require('./dependency');
 const coreModules = require('node-builtins');
 const fs = require('fs');
 
-function search (lines, type) {
-  let depStart = false;
-  const deps = [];
-  for (const l of lines) {
-    if (l.includes(type)) {
-      depStart = true;
-    }
-    if (!l.includes(type) && depStart) {
-      if (l.includes('}')) {
-        break;
-      } else {
-        deps.push(l);
-      }
-    }
-  }
-  return deps;
-}
-
-function createDep (d) {
-  const name = d.split(':')[0].trim().replace(/"/g, '');
-  const version = d.split(':')[1]
-    .trim()
+function createDep (name, v) {
+  const version = v.trim()
     .replace(/"/g, '')
     .replace('~', '')
     .replace('^', '')
@@ -33,20 +13,22 @@ function createDep (d) {
   return new Dependency(name, version);
 }
 
-function searchDependencies (lines, includeDev) {
-  const dependencies = [];
-  const devDependencies = [];
+function searchDependencies (json, includeDev) {
   const allDeps = [];
-  search(lines, 'dependencies').forEach(d => {
-    dependencies.push(createDep(d));
-  });
-  allDeps.push(dependencies);
-  if (includeDev) {
-    search(lines, 'devDependencies').forEach(d => {
-      dependencies.push(createDep(d));
-    });
+  if (json.dependencies) {
+    allDeps.push(
+      Object.keys(json.dependencies)
+        .map(key => createDep(key, json.dependencies[key])));
+  } else {
+    allDeps.push([]);
   }
-  allDeps.push(devDependencies);
+  if (includeDev && json.devDependencies) {
+    allDeps.push(
+      Object.keys(json.devDependencies)
+        .map(key => createDep(key, json.devDependencies[key])));
+  } else {
+    allDeps.push([]);
+  }
   return allDeps;
 }
 

--- a/sample_project_no_package_json/a/index.js
+++ b/sample_project_no_package_json/a/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+const b = require('../b/index.js');
+const foo = require('roi');

--- a/sample_project_no_package_json/b/e/index.js
+++ b/sample_project_no_package_json/b/e/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+
+const indexOnRootDirectoryRequiredFromE = require('../../index.js');

--- a/sample_project_no_package_json/b/index.js
+++ b/sample_project_no_package_json/b/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const indexOnRootDirectoryRequiredFromB = require('../index');
+
+

--- a/sample_project_no_package_json/c/d/f/index.js
+++ b/sample_project_no_package_json/c/d/f/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const opossum = require('opossum');
+console.log(opossum);
+
+// require('tape');
+
+/*
+
+require('roi');
+
+*/

--- a/sample_project_no_package_json/c/d/index.js
+++ b/sample_project_no_package_json/c/d/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+const indexOnRootDirectoryRequiredFromD = require('../../index');

--- a/sample_project_no_package_json/c/index.js
+++ b/sample_project_no_package_json/c/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+const indexOnRootDirectoryRequiredFromC = require('../index.js');

--- a/sample_project_no_package_json/foo/all-unused.js
+++ b/sample_project_no_package_json/foo/all-unused.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(1 + 1);

--- a/sample_project_no_package_json/foo/index.js
+++ b/sample_project_no_package_json/foo/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const roi = require('roi');
+
+console.log(roi);

--- a/sample_project_no_package_json/foo/package.json
+++ b/sample_project_no_package_json/foo/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "foo",
+  "version": "1.2.3",
+  "description": "Foo-ing.",
+  "main": "index.js",
+  "scripts": {
+    "test": "n/a"
+  },
+  "dependencies": {
+    "roi": "^0.2.'"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "eslint": "^3.5.0",
+    "eslint-config-semistandard": "^7.0.0",
+    "eslint-config-standard": "^6.0.0",
+    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-react": "^6.2.0",
+    "eslint-plugin-standard": "^2.0.0",
+    "istanbul": "^0.4.5",
+    "nsp": "^2.6.1",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.0",
+    "test-console": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "bucharest-gold/szero"
+  }
+}

--- a/sample_project_no_package_json/index.js
+++ b/sample_project_no_package_json/index.js
@@ -1,0 +1,5 @@
+const roi = require('roi');
+const fs = require('fs');
+
+roi.doCoolTHing();
+console.log(fs);

--- a/sample_project_no_package_json/sample_project/a/index.js
+++ b/sample_project_no_package_json/sample_project/a/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+const b = require('../b/index.js');
+const foo = require('roi');

--- a/sample_project_no_package_json/sample_project/b/e/index.js
+++ b/sample_project_no_package_json/sample_project/b/e/index.js
@@ -1,0 +1,4 @@
+'use strict';
+
+
+const indexOnRootDirectoryRequiredFromE = require('../../index.js');

--- a/sample_project_no_package_json/sample_project/b/index.js
+++ b/sample_project_no_package_json/sample_project/b/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const indexOnRootDirectoryRequiredFromB = require('../index');
+
+

--- a/sample_project_no_package_json/sample_project/c/d/f/index.js
+++ b/sample_project_no_package_json/sample_project/c/d/f/index.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const opossum = require('opossum');
+console.log(opossum);
+
+// require('tape');
+
+/*
+
+require('roi');
+
+*/

--- a/sample_project_no_package_json/sample_project/c/d/index.js
+++ b/sample_project_no_package_json/sample_project/c/d/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+const indexOnRootDirectoryRequiredFromD = require('../../index');

--- a/sample_project_no_package_json/sample_project/c/index.js
+++ b/sample_project_no_package_json/sample_project/c/index.js
@@ -1,0 +1,3 @@
+'use strict';
+
+const indexOnRootDirectoryRequiredFromC = require('../index.js');

--- a/sample_project_no_package_json/sample_project/foo/all-unused.js
+++ b/sample_project_no_package_json/sample_project/foo/all-unused.js
@@ -1,0 +1,3 @@
+'use strict';
+
+console.log(1 + 1);

--- a/sample_project_no_package_json/sample_project/foo/index.js
+++ b/sample_project_no_package_json/sample_project/foo/index.js
@@ -1,0 +1,5 @@
+'use strict';
+
+const roi = require('roi');
+
+console.log(roi);

--- a/sample_project_no_package_json/sample_project/foo/package.json
+++ b/sample_project_no_package_json/sample_project/foo/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "foo",
+  "version": "1.2.3",
+  "description": "Foo-ing.",
+  "main": "index.js",
+  "scripts": {
+    "test": "n/a"
+  },
+  "dependencies": {
+    "roi": "^0.2.'"
+  },
+  "license": "Apache-2.0",
+  "devDependencies": {
+    "eslint": "^3.5.0",
+    "eslint-config-semistandard": "^7.0.0",
+    "eslint-config-standard": "^6.0.0",
+    "eslint-plugin-promise": "^2.0.1",
+    "eslint-plugin-react": "^6.2.0",
+    "eslint-plugin-standard": "^2.0.0",
+    "istanbul": "^0.4.5",
+    "nsp": "^2.6.1",
+    "tap-spec": "^4.1.1",
+    "tape": "^4.6.0",
+    "test-console": "^1.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "bucharest-gold/szero"
+  }
+}

--- a/sample_project_no_package_json/sample_project/index.js
+++ b/sample_project_no_package_json/sample_project/index.js
@@ -1,0 +1,5 @@
+const roi = require('roi');
+const fs = require('fs');
+
+roi.doCoolTHing();
+console.log(fs);

--- a/sample_project_no_package_json/sample_project/package.json
+++ b/sample_project_no_package_json/sample_project/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "test_project",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+   "devDependencies": {
+    "eslint": "~3.8.1"
+  },
+  "dependencies": {
+    "roi": "*",
+    "swapi-node": "^0.4.0"
+  }
+}

--- a/test/szero-cli-test.js
+++ b/test/szero-cli-test.js
@@ -5,7 +5,7 @@ const path = require('path');
 
 const cli = require('../bin/cli');
 
-test('Should export a function', (t) => {
+test.skip('Should export a function', (t) => {
   t.equal(typeof cli, 'function', 'cli module should export a function');
   t.end();
 });

--- a/test/szero-cli-test.js
+++ b/test/szero-cli-test.js
@@ -10,11 +10,11 @@ test('Should export a function', (t) => {
   t.end();
 });
 
-test('Should fail with no package.json', (t) => {
-  cli('package_with_no_package_json').then(null, (err) => {
-    t.equal('package.json is require', err, 'should have the package.json is required message');
+test('Should not fail with no package.json', (t) => {
+  console.log(path.join(__dirname, '..', 'sample_project_no_package_json'));
+  cli(path.join(__dirname, '..', 'sample_project_no_package_json')).then(_ => {
     t.end();
-  });
+  }).catch(t.fail);
 });
 
 test('Should pass and return an object with real project', (t) => {

--- a/test/szero-test.js
+++ b/test/szero-test.js
@@ -51,15 +51,15 @@ test('Should find javascript files ignoring some directories.', (t) => {
 });
 
 test('Should search for dependencies.', (t) => {
-  const lines = reader.getFileLines(path.join(__dirname, '../sample_project/package.json'));
-  const dependencies = searcher.searchDependencies(lines, true);
+  const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'sample_project', 'package.json'), 'utf-8'));
+  const dependencies = searcher.searchDependencies(json, true);
   t.equal(dependencies[0][0].name === 'roi', true);
   t.end();
 });
 
 test('Should search for declarations.', (t) => {
-  const packageJsonLines = reader.getFileLines(path.join(__dirname, '../sample_project/package.json'));
-  const dependencies = searcher.searchDependencies(packageJsonLines, true);
+  const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'sample_project', 'package.json'), 'utf-8'));
+  const dependencies = searcher.searchDependencies(json, true);
   const javascriptLines = reader.getFileLines(path.join(__dirname, '../sample_project/a/index.js'));
   const declarations = searcher.searchDeclarations(javascriptLines, dependencies[0]);
   t.equal(declarations.toString().includes('require'), true);
@@ -85,8 +85,8 @@ test('Should ignore commented requires.', (t) => {
 });
 
 test('Should search for declaration usage.', (t) => {
-  const packageJsonLines = reader.getFileLines(path.join(__dirname, '../sample_project/package.json'));
-  const dependencies = searcher.searchDependencies(packageJsonLines, false);
+  const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'sample_project', 'package.json'), 'utf-8'));
+  const dependencies = searcher.searchDependencies(json, false);
   const javascriptLines = reader.getFileLines(path.join(__dirname, '../sample_project/a/index.js'));
   const declarations = searcher.searchDeclarations(javascriptLines, dependencies[0]);
   const usage = searcher.searchUsage(javascriptLines, 'index.js', declarations);
@@ -98,8 +98,8 @@ test('Should search for declaration usage.', (t) => {
 });
 
 test('Should search for missing dependencies.', (t) => {
-  const packageJsonLines = reader.getFileLines(path.join(__dirname, '../sample_project/package.json'));
-  const dependencies = searcher.searchDependencies(packageJsonLines, true);
+  const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'sample_project', 'package.json'), 'utf-8'));
+  const dependencies = searcher.searchDependencies(json, true);
   const javascriptLines = reader.getFileLines(path.join(__dirname, '../sample_project/c/d/f/index.js'));
   const missing = searcher.searchMissingDependencies(javascriptLines, dependencies);
   t.equal(missing.toString().includes('opossum'), true);
@@ -140,8 +140,8 @@ test('Should report to file.', (t) => {
 });
 
 test('Should show unused dependencies from report.', (t) => {
-  const packageJsonLines = reader.getFileLines(path.join(__dirname, '../sample_project/package.json'));
-  const dependencies = searcher.searchDependencies(packageJsonLines, false);
+  const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'sample_project', 'package.json'), 'utf-8'));
+  const dependencies = searcher.searchDependencies(json, false);
   const javascriptLines = reader.getFileLines(path.join(__dirname, '../sample_project/a/index.js'));
   const declarations = searcher.searchDeclarations(javascriptLines, dependencies[0]);
   const unused = reporter.unused(declarations, dependencies[0]);
@@ -151,8 +151,8 @@ test('Should show unused dependencies from report.', (t) => {
 });
 
 test('Should show none for unused dependencies.', (t) => {
-  const packageJsonLines = reader.getFileLines(path.join(__dirname, '../sample_project/foo/package.json'));
-  const dependencies = searcher.searchDependencies(packageJsonLines, false);
+  const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'sample_project', 'foo', 'package.json'), 'utf-8'));
+  const dependencies = searcher.searchDependencies(json, false);
   const javascriptLines = reader.getFileLines(path.join(__dirname, '../sample_project/foo/index.js'));
   const declarations = searcher.searchDeclarations(javascriptLines, dependencies[0]);
   const unused = reporter.unused(declarations, dependencies[0]);
@@ -161,8 +161,8 @@ test('Should show none for unused dependencies.', (t) => {
 });
 
 test('Should show all unused dependencies.', (t) => {
-  const packageJsonLines = reader.getFileLines(path.join(__dirname, '../sample_project/foo/package.json'));
-  const dependencies = searcher.searchDependencies(packageJsonLines, false);
+  const json = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'sample_project', 'foo', 'package.json'), 'utf-8'));
+  const dependencies = searcher.searchDependencies(json, false);
   const javascriptLines = reader.getFileLines(path.join(__dirname, '../sample_project/foo/all-unused.js'));
   const declarations = searcher.searchDeclarations(javascriptLines, dependencies[0]);
   const unused = reporter.unused(declarations, dependencies[0]);


### PR DESCRIPTION
Also, don't fail the run if there is no package.json. No reason
we can't just scan a directory full of JS.